### PR TITLE
Fix dev scripts and dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,19 +9,15 @@ Ejemplo de aplicación que muestra un listado de productos alimenticios y utiliz
 
 ## Uso rápido
 
-1. Instalar dependencias en ambos proyectos.
+1. Desde la raíz del repositorio instala todas las dependencias:
    ```bash
-   cd backend && npm install
-   cd ../next-app && npm install
+   npm install
    ```
-2. Ejecutar el backend de Nest.js:
-   ```bash
-   npm start
-   ```
-3. En otro terminal, ejecutar la app de Next.js:
+2. Levanta la aplicación completa:
    ```bash
    npm run dev
    ```
-4. Visitar `http://localhost:3000` y solicitar recomendaciones.
+   Se abrirá automáticamente `http://localhost:3000` en tu navegador.
+3. Solicita recomendaciones desde la página.
 
 Para que las recomendaciones funcionen es necesario tener corriendo un servidor `ollama` local en `http://localhost:11434`.

--- a/backend/package.json
+++ b/backend/package.json
@@ -13,5 +13,8 @@
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.8.1",
     "node-fetch": "^2.6.9"
+  },
+  "devDependencies": {
+    "@nestjs/cli": "^10.0.0"
   }
 }

--- a/next-app/pages/_app.js
+++ b/next-app/pages/_app.js
@@ -1,4 +1,4 @@
-import '@/styles/globals.css'
+import '../styles/globals.css'
 
 export default function App({ Component, pageProps }) {
   return <Component {...pageProps} />

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "kanter-otero-seminarioia",
+  "private": true,
+  "scripts": {
+    "postinstall": "npm install --prefix backend && npm install --prefix next-app",
+    "start-backend": "npm start --prefix backend",
+    "dev-next": "npm run dev --prefix next-app",
+    "open": "wait-on http://localhost:3000 && open-cli http://localhost:3000",
+    "dev": "concurrently -k \"npm run start-backend\" \"npm run dev-next\" \"npm run open\""
+  },
+  "devDependencies": {
+    "concurrently": "^8.2.2",
+    "open-cli": "^8.0.0",
+    "wait-on": "^7.0.1"
+  }
+}


### PR DESCRIPTION
## Summary
- add `@nestjs/cli` to backend for local dev
- fix Next.js import path
- use `open-cli` for auto-opening the browser

## Testing
- `npm run dev --silent` *(succeeds to start both servers and open browser)*

------
https://chatgpt.com/codex/tasks/task_e_685955fddbb08331bc26b1777b8e9cd5