### PR TITLE
Fix dev setup

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -4,7 +4,7 @@
   "main": "dist/main.js",
   "license": "MIT",
   "scripts": {
-    "start": "nest start"
+    "start": "npx nest start"
   },
   "dependencies": {
     "@nestjs/common": "^10.0.0",
@@ -13,5 +13,10 @@
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.8.1",
     "node-fetch": "^2.6.9"
+  },
+  "devDependencies": {
+    "@nestjs/cli": "^10.2.0",
+    "typescript": "^5.2.2",
+    "ts-node": "^10.9.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "concurrently": "^8.2.2",
-    "open": "^9.2.0",
+    "open": "^9.1.0",
     "wait-on": "^7.0.1"
   }
 }


### PR DESCRIPTION
## Summary
- fix incorrect open version
- allow backend to start without global `nest` by using `npx` and adding the CLI as a dev dependency

## Testing
- `npm install`
- `npm run dev` (terminated manually)


------
https://chatgpt.com/codex/tasks/task_e_68629112885c83318d46c786a9ce750b