### PR TITLE
Improve install reliability on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,13 @@ Ejemplo de aplicación que muestra un listado de productos alimenticios y utiliz
 
 ## Uso rápido
 
-1. Desde la raíz del repositorio instala todas las dependencias:
+1. Desde la raíz del repositorio instala todas las dependencias ejecutando:
    ```bash
    npm install
    ```
+   Este comando invoca `install.js`, un pequeño script que instala las
+   dependencias de `backend` y `next-app`. En Windows también puede ejecutarse
+   manualmente con `node install.js` si aparece algún problema con `npm`.
 2. Levanta la aplicación completa:
    ```bash
    npm run dev

--- a/install.js
+++ b/install.js
@@ -1,0 +1,14 @@
+const { execSync } = require('child_process');
+const npmCmd = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+
+function runInstall(dir) {
+  console.log(`\nInstalling dependencies in ${dir}...`);
+  execSync(`${npmCmd} install`, { cwd: dir, stdio: 'inherit' });
+}
+
+try {
+  runInstall('backend');
+  runInstall('next-app');
+} catch (err) {
+  process.exitCode = 1;
+}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kanter-otero-seminarioia",
   "private": true,
   "scripts": {
-    "postinstall": "npm install --prefix backend && npm install --prefix next-app",
+    "postinstall": "node install.js",
     "start-backend": "npm start --prefix backend",
     "dev-next": "npm run dev --prefix next-app",
     "open": "wait-on http://localhost:3000 && open http://localhost:3000",


### PR DESCRIPTION
## Summary
- add a small `install.js` helper to install sub-project dependencies
- use the helper in the root `postinstall` script
- update README instructions

## Testing
- `npm install --dry-run` *(fails: "Unknown env config 'http-proxy'")*

------
https://chatgpt.com/codex/tasks/task_e_686292f9691c83319d3a61c963fc2bc8