### PR TITLE
Fix open script and add Ollama setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,23 @@ Ejemplo de aplicación que muestra un listado de productos alimenticios y utiliz
 3. Solicita recomendaciones desde la página.
 
 Para que las recomendaciones funcionen es necesario tener corriendo un servidor `ollama` local en `http://localhost:11434`.
+
+## Configurar Ollama
+
+1. Descarga e instala `ollama` desde su [sitio oficial](https://ollama.ai/).
+   - En macOS o Linux puedes ejecutar:
+     ```bash
+     curl -fsSL https://ollama.ai/install.sh | sh
+     ```
+   - En Windows descarga e instala el ejecutable desde la misma página.
+2. Inicia el servicio local:
+   ```bash
+   ollama serve
+   ```
+   La primera vez puede que necesites descargar el modelo base con:
+   ```bash
+   ollama run llama2
+   ```
+   Esto deja escuchando `http://localhost:11434`.
+
+Con `ollama` corriendo ya puedes levantar la aplicación con `npm run dev`.

--- a/package.json
+++ b/package.json
@@ -5,12 +5,12 @@
     "postinstall": "node install.js",
     "start-backend": "npm start --prefix backend",
     "dev-next": "npm run dev --prefix next-app",
-    "open": "wait-on http://localhost:3000 && open http://localhost:3000",
+    "open": "wait-on http://localhost:3000 && open-cli http://localhost:3000",
     "dev": "concurrently --raw -k \"npm run start-backend\" \"npm run dev-next\" \"npm run open\""
   },
   "devDependencies": {
     "concurrently": "^8.2.2",
-    "open": "^9.1.0",
+    "open-cli": "^8.0.0",
     "wait-on": "^7.0.1"
   }
 }


### PR DESCRIPTION
## Summary
- use `open-cli` instead of the platform specific `open` command
- document how to install and run Ollama

## Testing
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_686b060dbb708331a529a8fac3605f62