### PR TITLE
Fix dev script keep backend running

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 node_modules
 .next
 backend/dist
+package-lock.json
+backend/package-lock.json
+next-app/package-lock.json

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "start-backend": "npm start --prefix backend",
     "dev-next": "npm run dev --prefix next-app",
     "open": "wait-on http://localhost:3000 && open-cli http://localhost:3000",
-    "dev": "concurrently --raw -k \"npm run start-backend\" \"npm run dev-next\" \"npm run open\""
+    "dev": "concurrently --raw \"npm run start-backend\" \"npm run dev-next\" \"npm run open\""
   },
   "devDependencies": {
     "concurrently": "^8.2.2",


### PR DESCRIPTION
## Summary
- update `npm run dev` command to avoid killing backend when auto-opening the website
- ignore `package-lock.json` files

## Testing
- `npm run dev > /tmp/dev.log 2>&1 & sleep 5; pkill -f concurrently; tail -n 20 /tmp/dev.log`

------
https://chatgpt.com/codex/tasks/task_e_686b099443648331b397a4b931560c83