### PR TITLE
Fix streaming for node-fetch

### DIFF
--- a/backend/src/recommend.controller.ts
+++ b/backend/src/recommend.controller.ts
@@ -14,14 +14,21 @@ export class RecommendController {
       body: JSON.stringify({ model: 'llama2', prompt })
     })
 
-    const reader = res.body?.getReader()
     let text = ''
-    if (reader) {
-      const decoder = new TextDecoder()
-      while (true) {
-        const { done, value } = await reader.read()
-        if (done) break
-        text += decoder.decode(value, { stream: true })
+    const bodyStream: any = res.body
+    if (bodyStream) {
+      if (typeof bodyStream.getReader === 'function') {
+        const reader = bodyStream.getReader()
+        const decoder = new TextDecoder()
+        while (true) {
+          const { done, value } = await reader.read()
+          if (done) break
+          text += decoder.decode(value, { stream: true })
+        }
+      } else {
+        for await (const chunk of bodyStream as any) {
+          text += chunk.toString()
+        }
       }
     }
 


### PR DESCRIPTION
## Summary
- handle streaming response from node-fetch

## Testing
- `npx -y tsc -p backend/tsconfig.json` *(fails: Cannot find module)*

------
https://chatgpt.com/codex/tasks/task_e_686b0fade4a88331807095a59bc53c28