### PR TITLE
Mejora experiencia de recomendación en español

### DIFF
--- a/backend/src/recommend.controller.ts
+++ b/backend/src/recommend.controller.ts
@@ -5,9 +5,10 @@ import fetch from 'node-fetch'
 export class RecommendController {
   @Post('recommend')
   async recommend(@Body() body: { preferences: string; products: string[] }) {
-    const prompt = `Tengo los siguientes productos: ${body.products.join(', ')}.\n` +
+    const prompt =
+      `Tengo los siguientes productos: ${body.products.join(', ')}.\n` +
       `El usuario prefiere: ${body.preferences}.\n` +
-      'Recomienda un solo producto de la lista.'
+      'Recomienda un solo producto de la lista y responde únicamente en español.'
     const res = await fetch('http://localhost:11434/api/generate', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },

--- a/next-app/pages/index.js
+++ b/next-app/pages/index.js
@@ -82,7 +82,7 @@ export default function Home() {
       <form onSubmit={handleSubmit} className="space-y-2">
         <textarea
           className="border p-2 w-full rounded"
-          placeholder="Ingresa tus preferencias"
+          placeholder="Describe tus preferencias (por ejemplo: me gustan las frutas dulces)"
           value={preferences}
           onChange={e => setPreferences(e.target.value)}
         />
@@ -94,7 +94,9 @@ export default function Home() {
         </div>
       )}
       {recommendation && !loading && (
-        <p className="mt-4 text-center">Recomendación: {recommendation}</p>
+        <div className="mt-4 p-4 bg-yellow-50 border-l-4 border-yellow-500 text-yellow-700 text-center font-semibold rounded">
+          Producto recomendado: {recommendation}
+        </div>
       )}
     </div>
   )


### PR DESCRIPTION
## Summary
- aseguro que las respuestas del modelo estén en español
- destaco la recomendación con un aviso resaltado
- se mejora el texto de ayuda para ingresar preferencias

## Testing
- `npm install`
- `npm run build --prefix next-app`
- `npx tsc -p backend/tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_6874f8c18be48331bea6279c3435b0e8