### PR TITLE
Improve recommendation display

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ Ejemplo de aplicación que muestra un listado de productos alimenticios y utiliz
    npm run dev
    ```
    Se abrirá automáticamente `http://localhost:3000` en tu navegador.
+
 3. Solicita recomendaciones desde la página.
+   Al obtener una respuesta el producto elegido se resaltará en la lista para que sea fácil de identificar.
 
 Para que las recomendaciones funcionen es necesario tener corriendo un servidor `ollama` local en `http://localhost:11434`.
 

--- a/next-app/pages/index.js
+++ b/next-app/pages/index.js
@@ -48,6 +48,7 @@ export default function Home() {
   const [preferences, setPreferences] = useState('')
   const [recommendation, setRecommendation] = useState('')
   const [loading, setLoading] = useState(false)
+  const [highlighted, setHighlighted] = useState('')
 
   const handleSubmit = async (e) => {
     e.preventDefault()
@@ -59,6 +60,10 @@ export default function Home() {
     })
     const data = await res.json()
     setRecommendation(data.recommendation)
+    const match = products.find(p =>
+      data.recommendation.toLowerCase().includes(p.name.toLowerCase())
+    )
+    setHighlighted(match ? match.name : '')
     setLoading(false)
   }
 
@@ -67,7 +72,10 @@ export default function Home() {
       <h1 className="text-3xl font-bold text-center">Lista de productos</h1>
       <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-3">
         {products.map(({ name, description, varieties, icon: Icon }) => (
-          <div key={name} className="border rounded-lg p-4 flex flex-col items-center space-y-2 bg-white shadow">
+          <div
+            key={name}
+            className={`border rounded-lg p-4 flex flex-col items-center space-y-2 bg-white shadow ${highlighted === name ? 'border-blue-500 bg-blue-50' : ''}`}
+          >
             <Icon className="text-3xl text-blue-600" />
             <h2 className="font-semibold">{name}</h2>
             <p className="text-sm text-gray-600 text-center">{description}</p>
@@ -95,7 +103,9 @@ export default function Home() {
       )}
       {recommendation && !loading && (
         <div className="mt-4 p-4 bg-yellow-50 border-l-4 border-yellow-500 text-yellow-700 text-center font-semibold rounded">
-          Producto recomendado: {recommendation}
+          {highlighted
+            ? `Producto recomendado: ${highlighted}`
+            : `Respuesta del modelo: ${recommendation}`}
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- highlight recommended product in the list
- show the chosen product name clearly
- document this behavior in the README

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*
- `npm run build` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6874fbdc33a083319cde5a5d901d27d9